### PR TITLE
chore(dx): replace commitlint with packaged action

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -6,14 +6,19 @@ on:
       - master
 
 jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v2
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: deps:install
       run: npm run bootstrap
-    - name: check:commits
-      run: npm run check:commits:ci
     - name: check:lint
       run: npm run check:lint
     - name: check:types

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [0, 'always', Infinity],
+  },
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "bootstrap": "scripts/bootstrap.sh",
     "check:commits": "commitlint --from=master --to=HEAD",
-    "check:commits:ci": "commitlint --from=origin/master --to=${GITHUB_SHA}",
     "check:lint": "eslint packages --ext=js,jsx,ts,tsx --no-error-on-unmatched-pattern",
     "check:types": "scripts/run-all.sh \"check:types\"",
     "test:ci": "scripts/run-all.sh \"test:ci\""


### PR DESCRIPTION
### Context

Replace the manual `commitlint` step I was running in my checks with this prepackaged solution:

https://github.com/wagoid/commitlint-github-action
